### PR TITLE
Removes themittani.com quote

### DIFF
--- a/components/TestimonialSlider.vue
+++ b/components/TestimonialSlider.vue
@@ -41,11 +41,6 @@ export default {
 			},
 			{
 				quote:
-					'The interconnected systems and sheer variety of content make SS13 utterly without peer.',
-				author: 'The Mittani.com',
-			},
-			{
-				quote:
 					'Almost anything is possible, every round is different, and everyone is insane. And those are just some of the reasons I love Space Station 13.',
 				author: 'PC GAMER',
 			},


### PR DESCRIPTION
themittani.com is a player-run fansite (of a player for a different game), and also no longer exists, I don't think. This quote shouldn't be next to quotes from actual gaming journalism sources.