### PR TITLE
Tweaks server status listing

### DIFF
--- a/components/HubServer.vue
+++ b/components/HubServer.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="hub-server">
-		<div v-dompurify-html="status" class="hub-server__status"></div>
+		<div v-dompurify-html="newStatus" class="hub-server__status"></div>
 		<div class="ml-4 text-center">
 			<a :href="`byond://BYOND.world.${urlId}`" class="cta cta--sm px-10">
 				Join
@@ -39,7 +39,41 @@ export default {
 		},
 	},
 
+	beforeMount() {
+		// Handle adding brackets to server text
+		const statusSplit = this.status.split("<br>");
+		let addPrefixBracket = false;
+		let addSuffixBracket = false;
+
+		if(statusSplit.length > 0) {
+			// Check first line
+			const leftFirstCount = statusSplit[0].split("[").length - 1;
+			const rightFirstCount = statusSplit[0].split("]").length - 1;
+			if(rightFirstCount > leftFirstCount) {
+				addPrefixBracket = true;
+			}
+
+			// Check last line
+			const leftLastCount = statusSplit[statusSplit.length - 1].split("[").length - 1;
+			const rightLastCount = statusSplit[statusSplit.length - 1].split("]").length - 1;
+			if(leftLastCount > rightLastCount) {
+				addSuffixBracket = true;
+			}
+		}
+
+		this.newStatus = this.status;
+
+		// Actually add it
+		if(addPrefixBracket) {
+			this.newStatus = "[" + this.newStatus;
+		}
+		if(addSuffixBracket) {
+			this.newStatus = this.newStatus + "]";
+		}
+	},
+
 	mounted() {
+		// Handle URLs
 		const links = this.$el.querySelectorAll('a')
 		for (const link of links) {
 			link.setAttribute('target', '_blank')

--- a/components/HubServer.vue
+++ b/components/HubServer.vue
@@ -39,37 +39,42 @@ export default {
 		},
 	},
 
-	beforeMount() {
-		// Handle adding brackets to server text
-		const statusSplit = this.status.split("<br>");
-		let addPrefixBracket = false;
-		let addSuffixBracket = false;
+	computed: {
+		newStatus() {
+			// Handle adding brackets to server text
+			let newStatus = this.status
+			const statusSplit = this.status.split('<br>')
+			let addPrefixBracket = false
+			let addSuffixBracket = false
 
-		if(statusSplit.length > 0) {
-			// Check first line
-			const leftFirstCount = statusSplit[0].split("[").length - 1;
-			const rightFirstCount = statusSplit[0].split("]").length - 1;
-			if(rightFirstCount > leftFirstCount) {
-				addPrefixBracket = true;
+			if (statusSplit.length > 0) {
+				// Check first line
+				const leftFirstCount = statusSplit[0].split('[').length - 1
+				const rightFirstCount = statusSplit[0].split(']').length - 1
+				if (rightFirstCount > leftFirstCount) {
+					addPrefixBracket = true
+				}
+
+				// Check last line
+				const leftLastCount =
+					statusSplit[statusSplit.length - 1].split('[').length - 1
+				const rightLastCount =
+					statusSplit[statusSplit.length - 1].split(']').length - 1
+				if (leftLastCount > rightLastCount) {
+					addSuffixBracket = true
+				}
 			}
 
-			// Check last line
-			const leftLastCount = statusSplit[statusSplit.length - 1].split("[").length - 1;
-			const rightLastCount = statusSplit[statusSplit.length - 1].split("]").length - 1;
-			if(leftLastCount > rightLastCount) {
-				addSuffixBracket = true;
+			// Actually add it
+			if (addPrefixBracket) {
+				newStatus = '[' + newStatus
 			}
-		}
+			if (addSuffixBracket) {
+				newStatus = newStatus + ']'
+			}
 
-		this.newStatus = this.status;
-
-		// Actually add it
-		if(addPrefixBracket) {
-			this.newStatus = "[" + this.newStatus;
-		}
-		if(addSuffixBracket) {
-			this.newStatus = this.newStatus + "]";
-		}
+			return newStatus
+		},
 	},
 
 	mounted() {


### PR DESCRIPTION
This allows for servers that balance their brackets to be more inline with the standard BYOND hub to render cleaner on this one.

Before:
![image](https://user-images.githubusercontent.com/25063394/159597703-36149415-37c5-4a20-8ef1-480c8db2e1aa.png)

After:
![image](https://user-images.githubusercontent.com/25063394/159597711-c34624a4-d6b0-443a-b019-50a7e34eaa10.png)

*Note Paradise & Fulpstation getting leading and trailing square brackets whereas goon is left fine*