### PR TITLE
Minor tweak to the twitter link

### DIFF
--- a/components/SiteNavLinks.vue
+++ b/components/SiteNavLinks.vue
@@ -27,7 +27,7 @@
 
 		<div class="social-links ml-auto pl-4 items-center flex gap-2">
 			<a
-				href="https://twitter.com/SpaceStation13"
+				href="https://twitter.com/Spacestation13"
 				target="_blank"
 				rel="external"
 				aria-label="Twitter"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25063394/176018348-6fa45dae-dffc-43de-a256-759eb006d3cf.png)

The handle is `Spacestation13` without the capitalisation on the second S, whereas the URL doesn't capitalise the second S. It still takes you to the right page, but this looks better because the handle and the URL now match 