### PR TITLE
Fixes Manuel's Listing for /tg/station

### DIFF
--- a/content/servers.json5
+++ b/content/servers.json5
@@ -72,8 +72,8 @@ links (array): objects representing game join links:
 				},
 				{
 					title: 'Manuel',
-					ip: 'sybil.tgstation13.org',
-					port: 1448,
+					ip: 'manuel.tgstation13.org',
+					port: 1447,
 				},
 				{
 					title: 'TGMC',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34697715/233722375-75d5d3b2-dc1e-42e1-91b2-37c47e52f9e0.png)

I'm not sure when we switched over to this new IP and Port:

![image](https://user-images.githubusercontent.com/34697715/233722422-d263ac2f-f9fc-4753-8250-99acd7848d0f.png)

(via https://tgstation13.org/)

But, we have. Let's keep this website running and not bait people into thinking manuel is down 24/7.