### PR TITLE
Updates CM-SS13 play url

### DIFF
--- a/content/servers.json5
+++ b/content/servers.json5
@@ -100,7 +100,7 @@ links (array): objects representing game join links:
 					title: 'CM',
 					ip: 'play.cm-ss13.com',
 					port: 1400,
-					url: 'https://play.cm-ss13.com',
+					url: 'https://cm-ss13.com/play/main',
 				},
 			],
 		},


### PR DESCRIPTION
https://play.cm-ss13.com has been migrated to https://cm-ss13.com/play/main from what I understand. 

You can still connect directly using `byond://play.cm-ss13.com:1400`, so I've not changed the IP or the port.