### PR TITLE
Cleans up tgstation removed servers on website

### DIFF
--- a/content/servers/tgstation.json
+++ b/content/servers/tgstation.json
@@ -5,14 +5,9 @@
 	"tags": ["experienced", "lightrp", "mediumrp", "casual", "expert"],
 	"website": "https://tgstation13.org",
 	"description": [
-		"/tg/Station 13 (from the /tg/ (Traditional Games) section of 4chan), quickly became the primary open source upstream after Goonstation went closed source, making them the closest thing to 'vanilla' SS13. /tg/station has multiple servers at multiple locations and roleplaying levels, and annoyingly strides to fit their server perfectly between roleplay (RP) levels. Sybil and Basil in the US and Terry in the EU operate as middleground Low-RP/Medium-RP servers. A fourth server called Manuel operates as their middleground Medium-RP/High-RP server, with an EU version in the works since the dawn of man. The gameplay style is a comfortable middle-ground between Goonstation and Baystation 12, and a newbie shouldn’t have too many problems jumping in. They host yearly events that bring in members from the entire SS13 community."
+		"/tg/Station 13 (from the /tg/ (Traditional Games) section of 4chan), quickly became the primary open source upstream after Goonstation went closed source, making them the closest thing to 'vanilla' SS13. /tg/station has multiple servers at multiple locations and roleplaying levels, and annoyingly strides to fit their server perfectly between roleplay (RP) levels. Sybil in the US and Terry in the EU operate as middleground Low-RP/Medium-RP servers. A third server called Manuel operates as their middleground Medium-RP/High-RP server. The gameplay style is a comfortable middle-ground between Goonstation and Baystation 12, and a newbie shouldn’t have too many problems jumping in. They host yearly events that bring in members from the entire SS13 community."
 	],
 	"links": [
-		{
-			"title": "Basil",
-			"ip": "basil.tgstation13.org",
-			"port": 2337
-		},
 		{
 			"title": "Sybil",
 			"ip": "sybil.tgstation13.org",
@@ -32,11 +27,6 @@
 			"title": "TGMC",
 			"ip": "tgmc.tgstation13.org",
 			"port": 5337
-		},
-		{
-			"title": "Campbell",
-			"ip": "campbell.tgstation13.org",
-			"port": 6337
 		}
 	]
 }


### PR DESCRIPTION
These have been gone since the transition in ownership and I doubt there are any plans to bring them back. Let's just make the description more accurate until the tides turn and Basil/Campbell come back.